### PR TITLE
Fixes for ingest

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -54,19 +54,33 @@ def post_object(sample_id, file_dir, htsget_url):
     return response
 
 
+def post_to_dataset(sample_id, dataset, htsget_url):
+    obj = {
+        "id": dataset,
+        "drsobjects": [
+            f"drs://localhost/{sample_id}"
+        ]
+    }
+    url = f"{htsget_url}/ga4gh/drs/v1/datasets"
+    response = requests.post(url, json=obj)
+
+
 def main():
     parser = argparse.ArgumentParser(description="A script that ingests a sample vcf and its index into htsget.")
 
     parser.add_argument("sample", help="sample id.")
     parser.add_argument("dir", help="file directory.")
     parser.add_argument("server_url", help="URL of the htsget server.")
+    parser.add_argument("dataset", help="dataset name")
 
     args = parser.parse_args()
     sample = args.sample
     file_dir = args.dir
     server_url = args.server_url
+    dataset = args.dataset
 
     post_object(sample, file_dir, server_url)
+    post_to_dataset(sample, dataset, server_url)
 
 
 if __name__ == "__main__":

--- a/ingest.sh
+++ b/ingest.sh
@@ -29,7 +29,7 @@ do
         com="docker exec $candig_server candig_repo add-variantset candig-example-data/registry.db $DATASET $val -R hs37d5"
         eval $com
         # ingest data into htsget
-        val=`echo $sample | awk -F, '{print "python htsget_ingest.py " $4 " /samples/ http://$CANDIG_DOMAIN:$HTSGET_APP_PORT"}'`
+        val=`echo $sample | awk -F, '{print "python htsget_ingest.py " $4 " /samples/ http://$CANDIG_DOMAIN:$HTSGET_APP_PORT $DATASET"}'`
         eval $val
 
     fi

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -114,6 +114,9 @@ def create_table(katsu_server_url, dataset_uuid, table_name, data_type):
         for r in results.json()["results"]:
             if r["name"] == table_name:
                 return r["identifier"]
+    else:
+        print(r3.json())
+        sys.exit()
 
 
 def ingest_data(katsu_server_url, table_id, data_file, data_type):

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -43,12 +43,10 @@ def create_project(katsu_server_url, project_title):
         )
         return project_uuid
     elif r.status_code == 400:
-        print(
-            "A project of title '{}' exists, please choose a different title, or delete this project.".format(
-                project_title
-            )
-        )
-        sys.exit()
+        results = requests.get(katsu_server_url + "/api/projects")
+        for r in results.json()["results"]:
+            if r["title"] == project_title:
+                return r["identifier"]
     else:
         print(r.json())
         sys.exit()
@@ -83,12 +81,10 @@ def create_dataset(katsu_server_url, project_uuid, dataset_title):
         )
         return dataset_uuid
     elif r2.status_code == 400:
-        print(
-            "A dataset of title '{}' exists, please choose a different title, or delete this dataset.".format(
-                dataset_title
-            )
-        )
-        sys.exit()
+        results = requests.get(katsu_server_url + "/api/datasets")
+        for r in results.json()["results"]:
+            if r["title"] == dataset_title:
+                return r["identifier"]
     else:
         print(r2.json())
         sys.exit()
@@ -113,9 +109,11 @@ def create_table(katsu_server_url, dataset_uuid, table_name, data_type):
         table_id = r3.json()["id"]
         print("Table {} with uuid {} has been created!".format(table_name, table_id))
         return table_id
-    else:
-        print("Something else went wrong. It might be that your a table with the same name already exists.")
-        sys.exit()
+    elif r3.status_code == 500:
+        results = requests.get(katsu_server_url + "/api/tables")
+        for r in results.json()["results"]:
+            if r["name"] == table_name:
+                return r["identifier"]
 
 
 def ingest_data(katsu_server_url, table_id, data_file, data_type):

--- a/mappings/synthetic2mcode/mcode.csv
+++ b/mappings/synthetic2mcode/mcode.csv
@@ -6,4 +6,8 @@
 "subject.deceased",{has_value("Date of Death")}
 "subject.ethnicity",{single_val(Ethnicity)}
 "date_of_death",{date("Date of Death")}
+"genomics_report.id",{single_val(Subject)}
+"genomics_report.code",{mcode.connect_code("1000 Genomes_ID")}
+"genomics_report.performing_organization_name",{mcode.connect_org("1000 Genomes_ID")}
+"genomics_report.issued*",{mcode.date("1000 Genomes_ID")}
 "genomics_report.extra_properties",{mcode.connect_variant("1000 Genomes_ID")}

--- a/mappings/synthetic2mcode/mcode.py
+++ b/mappings/synthetic2mcode/mcode.py
@@ -6,3 +6,12 @@ def connect_variant(mapping):
     if genomic_id is None:
         return None
     return {"genomic_id": genomic_id}
+
+def connect_code(mapping):
+    return "code"
+    
+def connect_org(mapping):
+    return "org"
+    
+def date(mapping):
+    return "2022-04-05"


### PR DESCRIPTION
I didn't look at the results carefully from before:

* katsu was not actually parsing the genomics_reports objects because it apparently needed a bunch more fields
* htsget didn't actually put the new objects into a dataset

You might have to delete the existing datasets in katsu if you ingested mohccn-data before:
* Get the mcode-synthetic dataset's UUID from `http://<katsu url>/katsu/api/datasets` with the authentication as usual
* Delete the dataset: `curl -X "DELETE" "http://<katsu url>/katsu/api/datasets/<dataset uuid>"`
* Repeat for the mcode-synthetic project.

I figured this out when writing up https://candig.atlassian.net/wiki/spaces/CA/pages/633765889/API+workflows+to+access+CanDIGv2+microservices#Accessing-variant-files-(vcfs)-for-a-particular-clinical-sample, so that is a good workflow to test this.